### PR TITLE
cron_task/latestDistro.sh: skip btrfs-progs

### DIFF
--- a/cron_task/latestDistro.sh
+++ b/cron_task/latestDistro.sh
@@ -21,7 +21,7 @@ while read d; do
 	pkgList=$(awk -v d=$d 'BEGIN{ret=1} $1 == d {$1=""; print; ret=0} END{exit ret}' .distroList.orig) || {
 		r=$d
 		[[ "$r" =~ ^RHEL-?[0-9]\.[0-9]$ ]] && r=${r%%-*}-./${r##*-}
-		pkgList=$(vershow '^(kernel|nfs-utils|autofs|rpcbind|.*fs-?progs)-[0-9]+\..*' "/$r$" |
+		pkgList=$(vershow '^(kernel|nfs-utils|autofs|rpcbind|[^b].*fs-?progs)-[0-9]+\..*' "/$r$" |
 			grep -v ^= | sed -r 's/\..?el[0-9]+.?\.(x86_64|i686|noarch|ppc64le)\.rpm//g' |
 			uniq | xargs | sed -r 's/(.*)(\<kernel-[^ ]* )(.*)/\2\1\3/')
 	}


### PR DESCRIPTION
As we don't support btrfs now.

Signed-off-by: Xiong Zhou <xzhou@redhat.com>