### PR TITLE
utils/brewkoji_install.sh fix certificate has expired

### DIFF
--- a/utils/brewkoji_install.sh
+++ b/utils/brewkoji_install.sh
@@ -32,13 +32,13 @@ installBrew2() {
 		[56])
 			for type in server client workstation; do
 				curl -L -O http://download.devel.redhat.com/rel-eng/RCMTOOLS/rhel-${verx}/rcm-tools-rhel-${verx}-${type}.repo
-				yum install -y koji brewkoji && break || rm rcm-tools-*.repo
+				yum install --setopt=sslverify=0 -y koji brewkoji && break || rm rcm-tools-*.repo
 			done
 			;;
 		7)
 			for type in server client workstation; do
 				curl -L -O http://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-rhel-${verx}-${type}.repo
-				yum install -y koji brewkoji && break || rm rcm-tools-*.repo
+				yum install --setopt=sslverify=0 -y koji brewkoji && break || rm rcm-tools-*.repo
 			done
 			;;
 		8|9)
@@ -51,7 +51,7 @@ installBrew2() {
 		esac
 	elif [[ $(rpm -E %fedora) != %fedora ]]; then
 		curl -L -O http://download.devel.redhat.com/rel-eng/internal/rcm-tools-fedora.repo
-		yum install -y koji brewkoji || rm rcm-tools-*.repo
+		yum install --setopt=sslverify=0 -y koji brewkoji || rm rcm-tools-*.repo
 	fi
 	popd
 
@@ -69,8 +69,9 @@ which brew &>/dev/null ||
 	if ! egrep -q '^!?epel' < <(yum repolist 2>/dev/null); then
 		[[ "$OSV" != "%rhel" ]] && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OSV}.noarch.rpm 2>/dev/null
 	fi
-	yum --setopt=strict=0 install -y koji python3-koji python3-pycurl brewkoji
+	yum --setopt=strict=0 --setopt=sslverify=0 install -y koji python3-koji python3-pycurl brewkoji
 which brew &>/dev/null || installBrew2
-yum install -y bash-completion-brew
+yum install --setopt=sslverify=0 -y bash-completion-brew
 
 which brew
+rm -rf /etc/yum.repos.d/rcm-tools-*.repo


### PR DESCRIPTION
utils/brewkoji_install.sh fix Curl error (60): Peer certificate cannot be authenticated with given CA certificates the CA of rcm-tools-rhel-8-baseos-rpms repo expired. It will prevent the host from installing the rest of the rpm packages normally because the ca certificate of this repo source expires. Delete the repo source at the end of brewkoji_install execution.

For example:
# yum makecache
Failed to set locale, defaulting to C.UTF-8
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

beaker-AppStream                                                                                                                   1.3 MB/s | 3.2 kB     00:00    
beaker-AppStream-debuginfo                                                                                                         962 kB/s | 1.5 kB     00:00    
beaker-BaseOS                                                                                                                      1.9 MB/s | 2.8 kB     00:00    
beaker-BaseOS-debuginfo                                                                                                            889 kB/s | 1.5 kB     00:00    
beaker-CRB                                                                                                                         2.1 MB/s | 3.2 kB     00:00    
beaker-CRB-debuginfo                                                                                                               1.2 MB/s | 1.5 kB     00:00    
beaker-HighAvailability                                                                                                            1.8 MB/s | 2.8 kB     00:00    
beaker-HighAvailability-debuginfo                                                                                                  1.1 MB/s | 1.5 kB     00:00    
beaker-NFV                                                                                                                         2.1 MB/s | 2.7 kB     00:00    
beaker-NFV-debuginfo                                                                                                               1.1 MB/s | 1.5 kB     00:00    
beaker-RT                                                                                                                          1.6 MB/s | 2.7 kB     00:00    
beaker-RT-debuginfo                                                                                                                890 kB/s | 1.5 kB     00:00    
beaker-ResilientStorage                                                                                                            2.0 MB/s | 2.8 kB     00:00    
beaker-ResilientStorage-debuginfo                                                                                                  1.2 MB/s | 1.5 kB     00:00    
beaker-SAP                                                                                                                         1.7 MB/s | 2.7 kB     00:00    
beaker-SAP-debuginfo                                                                                                               1.0 MB/s | 1.5 kB     00:00    
beaker-SAPHANA                                                                                                                     2.0 MB/s | 2.7 kB     00:00    
beaker-SAPHANA-debuginfo                                                                                                           995 kB/s | 1.5 kB     00:00    
beaker-buildroot                                                                                                                    46 kB/s | 2.0 kB     00:00    
beaker-harness                                                                                                                     1.1 MB/s | 1.3 kB     00:00    
beaker-tasks                                                                                                                        89 MB/s | 5.6 MB     00:00    
Extra Packages for Enterprise Linux 8 - x86_64                                                                                     119 kB/s |  24 kB     00:00    
Extra Packages for Enterprise Linux Modular 8 - x86_64                                                                             169 kB/s |  24 kB     00:00    
RCM Tools for Red Hat Enterprise Linux 8 BaseOS (RPMs)                                                                             0.0  B/s |   0  B     00:00    
Errors during downloading metadata for repository 'rcm-tools-rhel-8-baseos-rpms':
  - Curl error (60): Peer certificate cannot be authenticated with given CA certificates for https://download.devel.redhat.com/rel-eng/RCMTOOLS/latest-RCMTOOLS-2-RHEL-8/compose/BaseOS/x86_64/os/repodata/repomd.xml [SSL certificate problem: certificate has expired]
Error: Failed to download metadata for repo 'rcm-tools-rhel-8-baseos-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried