### PR TITLE
gen_job_xml: fix familyX.Y choosing wrong version

### DIFF
--- a/bkr-runtest/gen_job_xml
+++ b/bkr-runtest/gen_job_xml
@@ -585,9 +585,9 @@ job retention_tag=$retentionTag $productkv user=$jobOwner $jobCtl {
 							if {$verx >= 8} {set VARIANT BaseOS}
 							if {$FamilyY != ""} {
 								if {$FamilyZ == ""} {
-									set DistroPattern %${FamilyX}.${FamilyY}%
+									set DistroPattern RHEL-${FamilyX}.${FamilyY}.%
 								} else {
-									set DistroPattern %${FamilyX}.${FamilyY}.${FamilyZ}%
+									set DistroPattern RHEL-${FamilyX}.${FamilyY}.${FamilyZ}-%
 								}
 								lappend drs distro_name~${DistroPattern}
 							}


### PR DESCRIPTION
Choosing distro with family9.2 might fail, choosing for example the distro RHEL-9.0.0-updates-20230209.23, because it also matchs to the regex %9.2%. Fix it with a more exhaustive regex.

Signed-off-by: Íñigo Huguet <ihuguet@redhat.com>