### PR TITLE
utils/brewkoji_install.sh fix OSV is empty issue.

### DIFF
--- a/utils/brewkoji_install.sh
+++ b/utils/brewkoji_install.sh
@@ -68,12 +68,13 @@ installBrew2() {
 (cd /etc/pki/ca-trust/source/anchors && curl -Ls --remote-name-all https://certs.corp.redhat.com/{2022-IT-Root-CA.pem,2015-IT-Root-CA.pem,ipa.crt,mtls-ca-validators.crt,RH-IT-Root-CA.crt} && update-ca-trust)
 
 # install koji & brew
-which brew &>/dev/null ||
+which brew &>/dev/null || {
 	OSV=$(rpm -E %rhel)
 	if ! grep -E -q '^!?epel' < <(yum repolist 2>/dev/null); then
 		[[ "$OSV" != "%rhel" ]] && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OSV}.noarch.rpm 2>/dev/null
 	fi
 	yum --setopt=strict=0 --setopt=sslverify=0 install -y koji python3-koji python3-pycurl brewkoji
+}
 which brew &>/dev/null || installBrew2
 yum install --setopt=sslverify=0 -y bash-completion-brew
 

--- a/utils/brewkoji_install.sh
+++ b/utils/brewkoji_install.sh
@@ -76,7 +76,7 @@ which brew &>/dev/null || {
 	yum --setopt=strict=0 --setopt=sslverify=0 install -y koji python3-koji python3-pycurl brewkoji
 }
 which brew &>/dev/null || installBrew2
-yum install --setopt=sslverify=0 -y bash-completion-brew
+which brew &>/dev/null || yum install --setopt=sslverify=0 -y bash-completion-brew
 
-which brew
+which brew || echo "install brew failed!!!"
 rm -rf /etc/yum.repos.d/rcm-tools-*.repo


### PR DESCRIPTION
If brew already installed, OSV is empty. It will print false failed when yum install.