### PR TITLE
brewkoji_install.sh fix rhel6/7 didn't install RCMTOOLS, disable rhel5 support

### DIFF
--- a/utils/brewkoji_install.sh
+++ b/utils/brewkoji_install.sh
@@ -32,8 +32,9 @@ installBrew2() {
 		baseUrl=http://download.eng.pek2.redhat.com/rhel-$verx
 	if [[ $(rpm -E %rhel) != %rhel ]]; then
 		case $verx in
-		[567])
-			type=workstation
+		# https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=RCMDOC&title=RCM+Tools+Release+Guide
+		[67])
+			type=Workstation
 			pkglist='koji brewkoji'
 			;;
 		8|9)


### PR DESCRIPTION
[root@localhost ~]# yum install koji-1.21.1-1.el7
Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager

This system is not registered with an entitlement server. You can use subscription-manager to register.

Resolving Dependencies
--> Running transaction check
---> Package koji.noarch 0:1.21.1-1.el7 will be installed --> Processing Dependency: python2-koji = 1.21.1-1.el7 for package: koji-1.21.1-1.el7.noarch --> Processing Dependency: python-libcomps for package: koji-1.21.1-1.el7.noarch --> Running transaction check
---> Package koji.noarch 0:1.21.1-1.el7 will be installed --> Processing Dependency: python-libcomps for package: koji-1.21.1-1.el7.noarch ---> Package python2-koji.noarch 0:1.21.1-1.el7 will be installed --> Processing Dependency: python-requests for package: python2-koji-1.21.1-1.el7.noarch --> Processing Dependency: python-requests-kerberos for package: python2-koji-1.21.1-1.el7.noarch --> Running transaction check
---> Package koji.noarch 0:1.21.1-1.el7 will be installed --> Processing Dependency: python-libcomps for package: koji-1.21.1-1.el7.noarch ---> Package python-requests.noarch 0:2.6.0-10.el7 will be installed --> Processing Dependency: python-urllib3 >= 1.10.2-1 for package: python-requests-2.6.0-10.el7.noarch ---> Package python-requests-kerberos.noarch 0:0.7.0-2.el7 will be installed --> Processing Dependency: python-kerberos for package: python-requests-kerberos-0.7.0-2.el7.noarch --> Running transaction check
---> Package koji.noarch 0:1.21.1-1.el7 will be installed --> Processing Dependency: python-libcomps for package: koji-1.21.1-1.el7.noarch ---> Package python-kerberos.x86_64 0:1.1-15.el7 will be installed ---> Package python-urllib3.noarch 0:1.10.2-7.el7 will be installed --> Finished Dependency Resolution
Error: Package: koji-1.21.1-1.el7.noarch (epel)
           Requires: python-libcomps
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
[root@localhost ~]# yum provides python-libcomps
Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager

This system is not registered with an entitlement server. You can use subscription-manager to register.

RHEL-AppStream/x86_64/filelists                                                                         | 3.9 MB  00:00:01
RHEL-BaseOS/x86_64/filelists                                                                            | 3.1 MB  00:00:00
RHEL-NFV/x86_64/filelists                                                                               | 401 kB  00:00:00
RHEL-RT/x86_64/filelists                                                                                | 401 kB  00:00:00
beaker-harness/filelists                                                                                | 1.3 MB  00:00:03
beaker-tasks/filelists                                                                                  | 2.2 MB  00:00:04
https://mirror.01link.hk/epel/7/x86_64/repodata/caa1d1fdadd8a9b64b53c20d82c6b077e25172a4d8df437f752a2c81b2a23fe0-filelists.sqlite.bz2: [Errno 14] curl#60 - "Peer's Certificate has expired."
Trying other mirror.
It was impossible to connect to the Red Hat servers.
This could mean a connectivity issue in your environment, such as the requirement to configure a proxy,
or a transparent proxy that tampers with TLS security, or an incorrect system clock.
Please collect information about the specific failure that occurs in your environment,
using the instructions in: https://access.redhat.com/solutions/1527033 and open a ticket with Red Hat Support.

epel/x86_64/filelists_db                                                                                |  12 MB  00:00:00
No matches found