### PR TITLE
utils/brewinstall.sh Repeated restarts caused by mixed installation of user packages and kernel packages

### DIFF
--- a/utils/brewinstall.sh
+++ b/utils/brewinstall.sh
@@ -615,10 +615,11 @@ if [[ -n "$kernelpath" ]]; then
 fi
 
 _reboot=no
-if ls *.$(arch).rpm 2>/dev/null|grep -E '^kernel-(redhat|rt-|64k-)?(debug-)?[0-9]'; then
+# need to check current kernel match default kernel, default kernel match target installed kernel.
+default_kernel_index=$(grubby --info=DEFAULT | grep index | sed 's/index=//')
+current_kernel_index=$(grubby --info="/boot/vmlinuz-$(uname -r)" | grep index | sed 's/index=//')
+if ls *.$(arch).rpm 2>/dev/null|grep -E "${kernelpath}" && [[ ${default_kernel_index} -ne ${current_kernel_index} ]]; then
 	[[ "$KREBOOT" = yes ]] && _reboot=yes
 fi
-if grep -E -w 'rtk|64k' <<<"${builds[*]}"; then
-	[[ "$KREBOOT" = yes ]] && _reboot=yes
-fi
+
 [[ $_reboot = yes ]] && reboot || exit 0


### PR DESCRIPTION
If you run below commands, you can hit this issue.
brewinstall.sh libvirt-8.0.0-22.module+el8.9.0+19544+b3045133 kernel-4.18.0-527.el8
yum update libvirt #<<<<update to 8.00.23
brewinstall.sh libvirt-8.0.0-22.module+el8.9.0+19544+b3045133 kernel-4.18.0-527.el8

reboot only occurred when default kernel didn't match target kernel(provide by your cmdline.)