### PR TITLE
utils/brewinstall.sh Repeated restarts caused by mixed installation of user packages and kernel packages

### DIFF
--- a/utils/brewinstall.sh
+++ b/utils/brewinstall.sh
@@ -534,7 +534,7 @@ if [[ $buildcnt -gt 0 ]]; then
 	}
 else
 	INSTALL_TYPE=nothing
-	if ! grep -E -w 'rtk|64k' <<<"${builds[*]}"; then
+	if ! grep -E -w 'rtk|64k|kernel' <<<"${builds[*]}"; then
 		exit 0
 	fi
 fi
@@ -615,10 +615,11 @@ if [[ -n "$kernelpath" ]]; then
 fi
 
 _reboot=no
-if ls *.$(arch).rpm 2>/dev/null|grep -E '^kernel-(redhat|rt-|64k-)?(debug-)?[0-9]'; then
+# need to check current kernel match default kernel, default kernel match target installed kernel.
+default_kernel_index=$(grubby --info=DEFAULT | grep index | sed 's/index=//')
+current_kernel_index=$(grubby --info="/boot/vmlinuz-$(uname -r)" | grep index | sed 's/index=//')
+if rpm -qlp *.$(arch).rpm 2>/dev/null|grep -E "${kernelpath}" && [[ ${default_kernel_index} -ne ${current_kernel_index} ]]; then
 	[[ "$KREBOOT" = yes ]] && _reboot=yes
 fi
-if grep -E -w 'rtk|64k' <<<"${builds[*]}"; then
-	[[ "$KREBOOT" = yes ]] && _reboot=yes
-fi
+
 [[ $_reboot = yes ]] && reboot || exit 0


### PR DESCRIPTION
self test:
brewinstall.sh libvirt-8.0.0-22.module+el8.9.0+19544+b3045133 qemu-kvm-6.2.0-41.module+el8.10.0+20088+3901493e kernel-4.18.0-527.el8

reboot as well:
[04:12:20 root@ /root/kernel-master-networking/networking/temp]# grubby --default-kernel
/boot/vmlinuz-4.18.0-527.el8.x86_64
libvirt-8.0.0-22.module+el8.9.0+19544+b3045133 qemu-kvm-6.2.0-41.module+el8.10.0+20088+3901493e kernel-4.18.0-527.el8
[04:12:21 root@ /root/kernel-master-networking/networking/temp]# ls /boot/vmlinuz-*x86_64* -tl -u
-rwxr-xr-x. 1 root root 11043784 Mar 18 04:12 /boot/vmlinuz-4.18.0-527.el8.x86_64
-rwxr-xr-x. 1 root root 11043784 Mar 17 22:28 /boot/vmlinuz-4.18.0-526.el8.x86_64
[04:12:21 root@ /root/kernel-master-networking/networking/temp]# grubby --set-default=/boot/vmlinuz-4.18.0-527.el8.x86_64
The default is /boot/loader/entries/8e8e8c2f5dcb4a64958c74ab89638aee-4.18.0-527.el8.x86_64.conf with index 0 and kernel /boot/vmlinuz-4.18.0-527.el8.x86_64
/boot/vmlinuz-4.18.0-527.el8.x86_64
Connection to 192.168.122.136 closed by remote host.
Connection to 192.168.122.136 closed.

then I try update libvirt use yum command
# yum install libvirt -y

then I try re-run brewinstall and didn't reboot.
brewinstall.sh libvirt-8.0.0-22.module+el8.9.0+19544+b3045133 qemu-kvm-6.2.0-41.module+el8.10.0+20088+3901493e kernel-4.18.0-527.el8
[04:14:41 root@ /root/kernel-master-networking/networking/temp]# grubby --default-kernel
/boot/vmlinuz-4.18.0-527.el8.x86_64
libvirt-8.0.0-22.module+el8.9.0+19544+b3045133 qemu-kvm-6.2.0-41.module+el8.10.0+20088+3901493e kernel-4.18.0-527.el8
[04:14:42 root@ /root/kernel-master-networking/networking/temp]# ls /boot/vmlinuz-*x86_64* -tl -u
-rwxr-xr-x. 1 root root 11043784 Mar 18 04:14 /boot/vmlinuz-4.18.0-527.el8.x86_64
-rwxr-xr-x. 1 root root 11043784 Mar 17 22:28 /boot/vmlinuz-4.18.0-526.el8.x86_64
[04:14:42 root@ /root/kernel-master-networking/networking/temp]# grubby --set-default=/boot/vmlinuz-4.18.0-527.el8.x86_64
The default is /boot/loader/entries/8e8e8c2f5dcb4a64958c74ab89638aee-4.18.0-527.el8.x86_64.conf with index 0 and kernel /boot/vmlinuz-4.18.0-527.el8.x86_64
/boot/vmlinuz-4.18.0-527.el8.x86_64
