### PR TITLE
Mhou tmp branch

### DIFF
--- a/bkr-runtest/gen_job_xml
+++ b/bkr-runtest/gen_job_xml
@@ -128,7 +128,7 @@ if {[info exist Opt(opt-alias)] && $Opt(opt-alias) != ""} {
 	if [file isfile ${option-alias-path}] {
 		set aliasf ${option-alias-path}
 	} else {
-		exec bash -c "curl -Ls --noproxy '*' ${option-alias-path} -o ${aliasf}"
+		exec bash -c "curl -Lks --noproxy '*' ${option-alias-path} -o ${aliasf}"
 	}
 	source ${aliasf}
 	set idx [lindex [lsearch -all -regexp $ARGV {-(opt|hr)-alias(=.*)?$}] end]

--- a/utils/brewinstall.sh
+++ b/utils/brewinstall.sh
@@ -489,7 +489,9 @@ for build in "${builds[@]}"; do
 		fi
 		if [[ "$ONLY_DOWNLOAD" != yes && -z "$DEBUG_INFO_OPT" ]]; then
 			curknvr=kernel-$(uname -r)
-			if [[ "${build}" = ${curknvr%.*} && "$FLAG" != debugkernel && ! "${builds[*]}" =~ rtk|64k ]]; then
+			curmtype=$(uname -m)
+			curkname=$(echo ${curknvr} | sed -n "s/\(.*\).\(.$curmtype\)\(.*\)/\1\3/p")
+			if [[ "${build}" = "${curkname}" && "$FLAG" != debugkernel && ! "${builds[*]}" =~ rtk|64k ]]; then
 				report_result "kernel($build) has been installed" PASS
 				let buildcnt--
 				continue


### PR DESCRIPTION
brewinstall.sh first install rt kernel would let stock kernel install
failed.

In the interactive shell environment, first install kernel-5.14.0-467.el9.x86_64 rtk through brewinstall.sh, and then install kernel-5.14.0-467.el9, which fails.

+ curknvr=kernel-5.14.0-467.el9.x86_64+rt
+ [[ kernel-5.14.0-467.el9 = kernel-5.14.0-467.el9 ]]