### PR TITLE
brewinstall.sh first install rt kernel would let stock kernel install failed

### DIFF
--- a/bkr-runtest/gen_job_xml
+++ b/bkr-runtest/gen_job_xml
@@ -1143,7 +1143,7 @@ job retention_tag=$retentionTag $productkv user=$jobOwner $jobCtl {
 								set fname [file tail [dict get $duri path]]
 								set rpath "[dict get $duri host]/[file dirname [dict get $duri path]]"
 								set _cmd "curl -Lk --retry 64 --retry-delay 2 -O $uri --create-dirs --output-dir /var/cache/nrestraint/fetch-uri/$rpath"
-								set _cmd2 "extract.sh /var/cache/nrestraint/fetch-uri/$rpath/$fname /mnt/tests $fname"
+								set _cmd2 "extract.sh /var/cache/nrestraint/fetch-uri/$rpath/$fname /mnt/tests $fname; touch /mnt/tests/$fname/fetch.done"
 								append _ksfContent "_cmd='${_cmd}'\necho '{run} \$_cmd'\n\$_cmd\n"
 								append _ksfContent "_cmd2='${_cmd2}'\necho '{run} \$_cmd2'\n\$_cmd2\n"
 							}

--- a/utils/brewinstall.sh
+++ b/utils/brewinstall.sh
@@ -489,7 +489,9 @@ for build in "${builds[@]}"; do
 		fi
 		if [[ "$ONLY_DOWNLOAD" != yes && -z "$DEBUG_INFO_OPT" ]]; then
 			curknvr=kernel-$(uname -r)
-			if [[ "${build}" = ${curknvr%.*} && "$FLAG" != debugkernel && ! "${builds[*]}" =~ rtk|64k ]]; then
+			curmtype=$(uname -m)
+			curkname=$(echo ${curknvr} | sed -n "s/\(.*\).\(.$curmtype\)\(.*\)/\1\3/p")
+			if [[ "${build}" = "${curkname}" && "$FLAG" != debugkernel && ! "${builds[*]}" =~ rtk|64k ]]; then
 				report_result "kernel($build) has been installed" PASS
 				let buildcnt--
 				continue


### PR DESCRIPTION
In the interactive shell environment, first install kernel-5.14.0-467.el9.x86_64 rtk through brewinstall.sh, and then install kernel-5.14.0-467.el9, which fails.

```
+ curknvr=kernel-5.14.0-467.el9.x86_64+rt
+ [[ kernel-5.14.0-467.el9 = kernel-5.14.0-467.el9 ]]
```