### PR TITLE
enable bootc-direct option

### DIFF
--- a/bkr-runtest/gen_job_xml
+++ b/bkr-runtest/gen_job_xml
@@ -522,6 +522,34 @@ if {$harness in {r re res rest restr restra restrai restrain restraint rst}} {
 
 if [info exist Opt(ks-meta)] { append recipe_ks_meta " " {*}$Opt(ks-meta) }
 set ksAppend {}
+
+if {[info exist Opt(bootc-direct)]} {
+	set param_count [llength $Opt(bootc-direct)]
+	if {$param_count == 0} {
+		set Opt(bootc-direct) "images.paas.redhat.com/bootc/rhel-bootc:latest-10.0"
+		set Opt(port-script) "https://gitlab.cee.redhat.com/kernel-qe/networking/network-qe/-/snippets/9205/raw/main/enable-image-mode-testing.sh"
+	} elseif {$param_count == 1} {
+		set Opt(port-script) "https://gitlab.cee.redhat.com/kernel-qe/networking/network-qe/-/snippets/9205/raw/main/enable-image-mode-testing.sh"
+	} elseif {$param_count == 2} {
+		lassign $Opt(bootc-direct) bootc_value port_script_value
+		set Opt(bootc-direct) $bootc_value
+		set Opt(port-script) $port_script_value
+	}
+	append ksAppend "\nostreecontainer --url $Opt(bootc-direct)"
+	append ksAppend "\n%post --log=/root/my-bootc-mode-ks-post.log"
+	append ksAppend "\ncurl -ksfL $Opt(port-script) | bash"
+	append ksAppend "\n%end"
+}
+#set upstreamUrl git://git.app.eng.bos.redhat.com/linux.git
+#	set upstreamBranch master
+#	set upstreamTag HEAD
+#	if {$Opt(upstream) != ""} {
+#		lassign [split $Opt(upstream) { @}] url_branch tag
+#		lassign [split $url_branch "#"] url branch
+#		if {[string trim $url] != ""} {set upstreamUrl $url}
+#		if {[string trim $branch] != ""} {set upstreamBranch $branch}
+#		if {[string trim $tag] != ""} {set upstreamTag $tag}
+#	}
 if [info exist Opt(ks-pkgs)] {
 	append ksAppend "\n%packages --ignoremissing"
 	foreach ks $Opt(ks-pkgs) { append ksAppend "\n[string map {" " "\n"} $ks]" }

--- a/bkr-runtest/gen_job_xml
+++ b/bkr-runtest/gen_job_xml
@@ -532,16 +532,6 @@ if {[info exist Opt(bootc-direct)]} {
 	}
 	append ksAppend "\nostreecontainer --url $Opt(bootc-direct)"
 }
-#set upstreamUrl git://git.app.eng.bos.redhat.com/linux.git
-#	set upstreamBranch master
-#	set upstreamTag HEAD
-#	if {$Opt(upstream) != ""} {
-#		lassign [split $Opt(upstream) { @}] url_branch tag
-#		lassign [split $url_branch "#"] url branch
-#		if {[string trim $url] != ""} {set upstreamUrl $url}
-#		if {[string trim $branch] != ""} {set upstreamBranch $branch}
-#		if {[string trim $tag] != ""} {set upstreamTag $tag}
-#	}
 if [info exist Opt(ks-pkgs)] {
 	append ksAppend "\n%packages --ignoremissing"
 	foreach ks $Opt(ks-pkgs) { append ksAppend "\n[string map {" " "\n"} $ks]" }

--- a/bkr-runtest/gen_job_xml
+++ b/bkr-runtest/gen_job_xml
@@ -527,18 +527,10 @@ if {[info exist Opt(bootc-direct)]} {
 	set param_count [llength $Opt(bootc-direct)]
 	if {$param_count == 0} {
 		set Opt(bootc-direct) "images.paas.redhat.com/bootc/rhel-bootc:latest-10.0"
-		set Opt(port-script) "https://gitlab.cee.redhat.com/kernel-qe/networking/network-qe/-/snippets/9205/raw/main/enable-image-mode-testing.sh"
 	} elseif {$param_count == 1} {
-		set Opt(port-script) "https://gitlab.cee.redhat.com/kernel-qe/networking/network-qe/-/snippets/9205/raw/main/enable-image-mode-testing.sh"
-	} elseif {$param_count == 2} {
-		lassign $Opt(bootc-direct) bootc_value port_script_value
 		set Opt(bootc-direct) $bootc_value
-		set Opt(port-script) $port_script_value
 	}
 	append ksAppend "\nostreecontainer --url $Opt(bootc-direct)"
-	append ksAppend "\n%post --log=/root/my-bootc-mode-ks-post.log"
-	append ksAppend "\ncurl -ksfL $Opt(port-script) | bash"
-	append ksAppend "\n%end"
 }
 #set upstreamUrl git://git.app.eng.bos.redhat.com/linux.git
 #	set upstreamBranch master

--- a/share/common-options.tcl
+++ b/share/common-options.tcl
@@ -19,8 +19,7 @@ set CommonOptionList {
 				--task-fetch-url /distribution/kernelinstall@   #means disable fetch-url for this task
 				}}
 	bootc			{arg o	help {bootc mode. --bootc[=TAG]; for TAG see also: skopeo list-tags docker://images.paas.redhat.com/bootc/rhel-bootc}}
-	bootc-direct	{arg o	help {self image. --bootc-direct["image_url post-script"];default image_url is images.paas.redhat.com/bootc/rhel-bootc:latest-10.0
-	default post-script is https://gitlab.cee.redhat.com/kernel-qe/networking/network-qe/-/snippets/9205/raw/main/enable-image-mode-testing.sh }}
+	bootc-direct	{arg o	help {self image. --bootc-direct["image_url post-script"];default image_url is images.paas.redhat.com/bootc/rhel-bootc:latest-10.0}}
 	keepchanges		{arg n	help {see: https://restraint.readthedocs.io/en/latest/jobs.html#keeping-your-task-changes-intact}}
 	offkeepchanges		{arg n	help {see: https://restraint.readthedocs.io/en/latest/jobs.html#keeping-your-task-changes-intact}}
 	fetch-opts		{arg y	help {task fetch options, e.g: "retry=8 timeo=32 abort-fetch-fail"}}

--- a/share/common-options.tcl
+++ b/share/common-options.tcl
@@ -19,6 +19,8 @@ set CommonOptionList {
 				--task-fetch-url /distribution/kernelinstall@   #means disable fetch-url for this task
 				}}
 	bootc			{arg o	help {bootc mode. --bootc[=TAG]; for TAG see also: skopeo list-tags docker://images.paas.redhat.com/bootc/rhel-bootc}}
+	bootc-direct	{arg o	help {self image. --bootc-direct["image_url post-script"];default image_url is images.paas.redhat.com/bootc/rhel-bootc:latest-10.0
+	default post-script is https://gitlab.cee.redhat.com/kernel-qe/networking/network-qe/-/snippets/9205/raw/main/enable-image-mode-testing.sh }}
 	keepchanges		{arg n	help {see: https://restraint.readthedocs.io/en/latest/jobs.html#keeping-your-task-changes-intact}}
 	offkeepchanges		{arg n	help {see: https://restraint.readthedocs.io/en/latest/jobs.html#keeping-your-task-changes-intact}}
 	fetch-opts		{arg y	help {task fetch options, e.g: "retry=8 timeo=32 abort-fetch-fail"}}


### PR DESCRIPTION
runtest --distro=RHEL-10.0-20250314.2 --product=cpe:/o:redhat:enterprise_linux --retention-tag=active+1 --variant=BaseOS --arch=x86_64 --systype=machine --machine="dell-per740-43.rhts.eng.pek2.redhat.com" --bootc-direct="quay.io/rhn_support_hewang/bootc-rhel10" --wb 'bootc-direct tes

https://beaker.engineering.redhat.com/jobs/10812981