### PR TITLE
utils/sshbkr remove -Y options becasue almost beaker server forbidden X11 forward.

### DIFF
--- a/utils/sshbkr
+++ b/utils/sshbkr
@@ -21,7 +21,7 @@ set USER root
 set SERVER [lindex $argv 0]
 set sshOpt [lrange $argv 1 end]
 
-spawn bash -c "TERM=xterm ssh -Y $sshOpt -l $USER $SERVER \
+spawn bash -c "TERM=xterm ssh $sshOpt -l $USER $SERVER \
 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
 
 expect {


### PR DESCRIPTION

if enable -Y option to login a beaker server which disable X11 forward, the login speed is very slow.

https://redhat.service-now.com/help?id=rh_ticket&table=sc_req_item&sys_id=0a8c85cb47f1a6904d8b409c716d4369