### PR TITLE
bkr-runtest/gen_job_xml fix the client site have redunant PART_MPS on mutihost task

### DIFF
--- a/bkr-runtest/gen_job_xml
+++ b/bkr-runtest/gen_job_xml
@@ -743,6 +743,14 @@ job retention_tag=$retentionTag $productkv user=$jobOwner group=$groupOwner $job
 		set FAMILY {}
 		set TAG {}
 		set R {0};	# Role index
+		if {${bootc-mode} == "fromPkgMode"} {
+			lappend Opt(part) {fs=ext4 name=/var/nfsshare size=5 type=part}
+		}
+		if [info exist Opt(part)] {
+			foreach part $Opt(part) {
+				append PART_MPS [regsub {.*name=([^ ]+).*} $part {\1}],
+				}
+		}
 		foreach role ${ROLE_LIST} {
 			if [llength $DISTRO_L] {
 				set DISTRO [lindex $DISTRO_L 0]
@@ -1001,12 +1009,8 @@ job retention_tag=$retentionTag $productkv user=$jobOwner group=$groupOwner $job
 					}
 				}
 				partitions ! {
-					if {${bootc-mode} == "fromPkgMode"} {
-						lappend Opt(part) {fs=ext4 name=/var/nfsshare size=5 type=part}
-					}
 					if [info exist Opt(part)] {
 						foreach part $Opt(part) {
-							append PART_MPS [regsub {.*name=([^ ]+).*} $part {\1}],
 							partition {*}$part -
 						}
 					}


### PR DESCRIPTION
original issue
```
runtest RHEL-9.7.0-20250603.2 --machine=dell-per740-43.rhts.eng.pek2.redhat.com,dell-per750-32.rhts.eng.pek2.redhat.com --systype=Machine  --bootc=RHEL-9.7.0-20250603.2 --topo=multiHost.1.1 -n
            <partitions>
                <partition fs="ext4" name="/var/nfsshare" size="5" type="part" />
                <partition fs="ext4" name="/var/nfsshare" size="5" type="part" />
            </partitions>
            <ks_appends>
                <ks_append><![CDATA[
part /boot --fstype=ext4
]]>

                </ks_append>
                <ks_append><![CDATA[
]]>

                </ks_append>
            </ks_appends>
            <task name="/network-qe/bootc-beaker/switch-pkg-to-image-mode" role="CLIENTS">
                <fetch url="https://gitlab.cee.redhat.com/kernel-qe/networking/network-qe/-/archive/main/network-qe-main.tar.gz#bootc-beaker/switch-pkg-to-image-mode" />
                <params>
                    <param name="DISTRO_BUILD" value="RHEL-9.7.0-20250603.2" />
                    <param name="BOOTC_TO" value="RHEL-9.7.0-20250603.2" />
                    <param name="PKGS" value="" />
                    <param name="BPKGS" value="" />
                    <param name="ScriptUrl" value="" />
                    <param name="PART_MPS" value="/var/nfsshare,/var/nfsshare,/var/nfsshare," />
                    <param name="REPOS" value="" />
                    <param name="KOPTS" value="" />
                    <param name="KILLTIMEOVERRIDE" value="345600" />
                    <param name="_fetch_opts" value="" />
                </params>
            </task>

```

after fixed
```
            <partitions>
                <partition fs="ext4" name="/var/nfsshare" size="5" type="part" />
            </partitions>
            <ks_appends>
                <ks_append><![CDATA[
part /boot --fstype=ext4
]]>

                </ks_append>
                <ks_append><![CDATA[
]]>

                </ks_append>
            </ks_appends>
            <task name="/network-qe/bootc-beaker/switch-pkg-to-image-mode" role="CLIENTS">
                <fetch url="https://gitlab.cee.redhat.com/kernel-qe/networking/network-qe/-/archive/main/network-qe-main.tar.gz#bootc-beaker/switch-pkg-to-image-mode" />
                <params>
                    <param name="DISTRO_BUILD" value="RHEL-9.7.0-20250603.2" />
                    <param name="BOOTC_TO" value="RHEL-9.7.0-20250603.2" />
                    <param name="PKGS" value="" />
                    <param name="BPKGS" value="" />
                    <param name="ScriptUrl" value="" />
                    <param name="PART_MPS" value="/var/nfsshare," />
                    <param name="REPOS" value="" />
                    <param name="KOPTS" value="" />
                    <param name="KILLTIMEOVERRIDE" value="345600" />
                    <param name="_fetch_opts" value="" />
                </params>
            </task>

```

the single host still work well
```
runtest RHEL-9.7.0-20250603.2 --machine=dell-per740-43.rhts.eng.pek2.redhat.com --systype=Machine  --bootc=RHEL-9.7.0-20250603.2 -n 
[runtest] *Remind*: No test specified, will reserve host(RHEL-9.7.0-20250603.2) for you
{debug}: replace DISTRO with compose-id of bootcTo:RHEL-9.7.0-20250603.2
[runtest] Test require: {}
[runtest] Generate job XML ==> 'job_20250610_15_07_distribution_RHEL-9_7_0-20250603_2_S_1_distribution_reservesys_--machine=dell-per740-43_rhts_eng_pek2_redhat_c.5744.xml'

<job retention_tag="60days" user="" group="">
    <whiteboard><![CDATA[[20250610~15:07] [distribution@RHEL-9.7.0-20250603.2 S:1] /distribution/reservesys: {--machine=dell-per740-43.rhts.eng.pek2.redhat.com --systype=Machine --bootc=RHEL-9.7.0-20250603.2}]]></whiteboard>
    <notify>
    </notify>
    <recipeSet priority="Normal">
        <recipe kernel_options="" kernel_options_post="" whiteboard="[20250610~15:07&#93; [distribution@RHEL-9.7.0-20250603.2 S:1&#93; /distribution/reservesys: {--machine=dell-per740-43.rhts.eng.pek2.redhat.com --systype=Machine --bootc=RHEL-9.7.0-20250603.2}" ks_meta="harness='restraint-rhts beakerlib' redhat_ca_cert disabled_root_access">
            <autopick random="false" />
            <distroRequires>
                <and>
                    <distro_method op="=" value="nfs" />
                    <distro_name op="=" value="RHEL-9.7.0-20250603.2" />
                    <distro_variant op="=" value="" />
                    <distro_arch op="=" value="x86_64" />
                </and>
                <or>
                </or>
                <not>
                    <or>
                    </or>
                </not>
            </distroRequires>
            <hostRequires>
                <and>
                    <hostname op="like" value="dell-per740-43.rhts.eng.pek2.redhat.com" />
                </and>
                <system_type op="=" value="Machine" />
            </hostRequires>
            <repos>
            </repos>
            <partitions>
                <partition fs="ext4" name="/var/nfsshare" size="5" type="part" />
            </partitions>
            <ks_appends>
                <ks_append><![CDATA[
part /boot --fstype=ext4
]]>

                </ks_append>
                <ks_append><![CDATA[
]]>

                </ks_append>
            </ks_appends>
            <task name="/network-qe/bootc-beaker/switch-pkg-to-image-mode" role="STANDALONE">
                <fetch url="https://gitlab.cee.redhat.com/kernel-qe/networking/network-qe/-/archive/main/network-qe-main.tar.gz#bootc-beaker/switch-pkg-to-image-mode" />
                <params>
                    <param name="DISTRO_BUILD" value="RHEL-9.7.0-20250603.2" />
                    <param name="BOOTC_TO" value="RHEL-9.7.0-20250603.2" />
                    <param name="PKGS" value="" />
                    <param name="BPKGS" value="" />
                    <param name="ScriptUrl" value="" />
                    <param name="PART_MPS" value="/var/nfsshare," />
                    <param name="REPOS" value="" />
                    <param name="KOPTS" value="" />
                    <param name="KILLTIMEOVERRIDE" value="345600" />
                    <param name="_fetch_opts" value="" />
                </params>
            </task>
            <task name="/distribution/reservesys" role="STANDALONE">
                <fetch url="https://pkgs.devel.redhat.com/git/tests/distribution/snapshot/distribution-master.tar.gz#reservesys" />
                <params>
                    <param name="_fetch_opts" value="" />
                    <param name="DISTRO_BUILD" value="RHEL-9.7.0-20250603.2" />
                </params>
            </task>
        </recipe>
    </recipeSet>
</job>

```
