### PR TITLE
brewinstall.sh fix false failed when no sub dir in download path

### DIFF
--- a/utils/brewinstall.sh
+++ b/utils/brewinstall.sh
@@ -518,7 +518,8 @@ for build in "${builds[@]}"; do
 			is_available_url $downloadServerUrl && {
 				finalUrl=$(curl -Ls -o /dev/null -w %{url_effective} $downloadServerUrl)
 				download_rpms_from_url $finalUrl
-				find */ -name '*.rpm' | xargs -i mv {} ./
+				#find . -mindepth 2 -type f -name "*.rpm" -exec sh -c 'mv "$@" ./' sh {} +
+				find . -mindepth 2 -type f -name "*.rpm" -print0 | xargs -0 mv -t ./ 
 			}
 		}
 	elif [[ "$build" =~ ^nfs: ]]; then
@@ -563,7 +564,7 @@ for build in "${builds[@]}"; do
 					bROpts=("${kROpts[@]}")
 				fi
 				download_rpms_from_url $url
-				find */ -name '*.rpm' | xargs -i mv {} ./
+				find . -mindepth 2 -type f -name "*.rpm" -print0 | xargs -0 mv -t ./ 
 			fi
 		done
 		if grep -q kenrel- ./ && [[ ${INSTALL_BOOTC} == 'yes' ]]; then
@@ -603,7 +604,7 @@ for build in "${builds[@]}"; do
 			which wget &>/dev/null || yum install -y wget
 			for url in $urls; do
 				download_rpms_from_url $url
-				find */ -name '*.rpm' | xargs -i mv {} ./
+				find . -mindepth 2 -type f -name "*.rpm" -print0 | xargs -0 mv -t ./ 
 			done
 		else
 			for a in "${archList[@]}"; do
@@ -722,3 +723,4 @@ else
 fi
 
 need_reboot && reboot || exit 0
+


### PR DESCRIPTION
{debug} paths: /brewroot/vol/rhel-10/packages/driverctl/0.115/2.el10/noarch/ {debug} url: https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/driverctl/0.115/2.el10/noarch/ [rpmFilter] accepts: *.x86_64.rpm *.noarch.rpm
[rpmFilter] rejects: *debug-*.rpm *debuginfo*.rpm *-doc-*.rpm [rpmFilter] rejects!:
␛[01;36m driverctl-0.115-2.el10.noarch.rpm didn't belong ^kernel* package, will install!␛[0m ␛[01;36m userspace accept: https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/driverctl/0.115/2.el10/noarch/driverctl-0.115-2.el10.noarch.rpm␛[0m _curl_download https://download-01.beak-001.prod.iad2.dc.redhat.com/brewroot/vol/rhel-10/packages/driverctl/0.115/2.el10/noarch/driverctl-0.115-2.el10.noarch.rpm &
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 26222  100 26222    0     0   624k      0 --:--:-- --:--:-- --:--:--  640k

real    0m0.089s
user    0m0.022s
sys     0m0.012s
find: '*/': No such file or directory