### PR TITLE
Remove hard dependency on NetworkManager and OpenVPN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,20 +71,11 @@ _install_require: _isroot _rh_intranet
 	@rpm -q sqlite-tcl >/dev/null || { yum install -y sqlite-tcl; exit 0; } #package that in default RHEL repo
 
 _rh_intranet:
-	@command -v host &>/dev/null || yum install bind-utils -y
-	@if ! host download.devel.redhat.com &>/dev/null; then \
+	@if ! getent hosts download.devel.redhat.com &>/dev/null; then \
 		tar -C / -zxf conf/rh-cert.tgz; update-ca-trust; \
-		\rm -f /etc/NetworkManager/system-connections/{.,}*.ovpn; \
-		tar -C / -zxf conf/rh-nm-openvpn-profiles.tgz; \
-		while read f; do cf=/$${f/.ovpn/.nmconnection}; \
-		    [[ "$${cf##*/}" = .* ]] && cf="$${cf/./_}"; \
-		    \rm -f "$${cf}"; \
-		done < <(tar tzf conf/rh-nm-openvpn-profiles.tgz); \
-		nmcli c r; \
-		nmcli c s|sed -rn '/vpn/{s/ *$$//;p}'; \
-		{ echo -e "[Warn] you have not connected in redhat intranet."; \
-		  echo -e " ref: https://redhat.service-now.com/help?id=kb_article_view&sysparm_article=KB0005424" >&2; \
-		  echo -e " try run: dovpn-connect.sh" >&2; exit 1; }; \
+		echo -e "[WARN] Not connected to Red Hat intranet!" >&2; \
+		echo -e " Please connect via VPN (WireGuard/OpenVPN) and retry." >&2; \
+		exit 1; \
 	fi
 
 _isroot:


### PR DESCRIPTION
The dependency on nm ovpn profile breaks installation, since user could be connected over WireGuard or inside a container. Fix this by just checking if the required domain is reachable.
Further, remove DNS query with host utility since it returns NXDOMAIN error for IPv6 record. Instead replace with getent hosts which returns true as long as the domain resolves to some address.